### PR TITLE
edits + restructuring

### DIFF
--- a/meetings.py
+++ b/meetings.py
@@ -1,7 +1,9 @@
+import sys
 import argparse
 import json
 import requests
 import time
+import contextlib
 from datetime import datetime
 from datetime import timedelta
 from os import getenv
@@ -10,80 +12,94 @@ from os.path import dirname, join
 from dotenv import load_dotenv
 load_dotenv(join(dirname(__file__), '.env'))
 
+KEY = getenv('ZOOM_KEY')
+SECRET = getenv('ZOOM_SECRET')
+API_BASE_URL = "https://api.zoom.us/v1"
+MEETING_TYPES = {"live": 1, "past": 2}
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--key", help="zoom api key")
-    parser.add_argument("--secret", help="zoom api secret")
-    parser.add_argument("--destination", help="destination filename")
-    args = parser.parse_args()
+class ZoomApiException(Exception):
+    pass
 
-    if args.key is None:
-        KEY = getenv('ZOOM_KEY')
+def get_meetings_from(date, type, key, secret):
 
-    if args.secret is None:
-        SECRET = getenv('ZOOM_SECRET')
-
-    FILENAME = args.destination
-    MEETINGS = "https://api.zoom.us/v1/metrics/meetings"
-
-    defaults = {
-        'api_key': KEY,
-        'api_secret': SECRET,
-        'type': "2",
-        'page_number': 1,
-        'page_size': "300",
+    params = {
+        'from': date,
+        'to': date,
+        'type': MEETING_TYPES[type],
+        'api_key': key,
+        'api_secret': secret,
+        'page_size': 100,
+        'page_number': 1
     }
 
-    meeting_types = {
-        'live': 1,
-        'past': 2
-    }
+    meetings = []
+    while True:
 
-    destination = open(FILENAME, "w")
+        r = requests.post(url=API_BASE_URL + "/metrics/meetings", data=params)
+        r.raise_for_status()
+        response = r.json()
 
-    def get_meetings_from(date, type):
-        params = defaults.copy()
-        params['from'] = date
-        params['to'] = date
-        params['type'] = meeting_types[type]
+        if 'error' in response.keys():
+            raise ZoomApiException(response['error'])
 
-        while True:
-            r = requests.post(url=MEETINGS, data=params)
+        for meeting in response['meetings']:
+            meeting['type'] = response['type']
+            meetings.append(meeting)
 
-            if r.status_code != requests.codes.ok:
-                print("Failed with status code:", r.status_code, "reason:", r.reason)
-                return
+        print("total", type, "meetings:", response['total_records'])
 
-            response = json.loads(r.text)
+        remaining_pages = response['page_count'] - response['page_number']
 
-            if 'error' in response.keys():
-                print(response)
-                return
+        if remaining_pages > 0:
+            print("wait", remaining_pages, "more minute(s)")
+            params['page_number'] += 1
+            # only 1 zoom api metrics request allowed per minute
+            time.sleep(60)
+        else:
+            break
 
-            for meeting in response['meetings']:
-                meeting['type'] = response['type']
-                destination.write(str(meeting))
+    return meetings
 
-            print("total", type, "meetings:", response['total_records'])
+@contextlib.contextmanager
+def open_destination(destination=None):
+    if destination == "-":
+        fh = sys.stdout
+    else:
+        fh = open(destination, "w")
+    try:
+        yield fh
+    finally:
+        if fh is not sys.stdout:
+            fh.close()
 
-            remaining_pages = response['page_count'] - response['page_number']
+def main(args):
 
-            if remaining_pages > 0:
-                print("wait", remaining_pages, "more minute(s)")
-                params['page_number'] += 1
-                # only 1 zoom api metrics request allowed per minute
-                time.sleep(60)
-            else:
-                break
-
-    yesterday = (datetime.today() - timedelta(days=1)).strftime('%Y-%m-%d')
-    get_meetings_from(yesterday, 'live')
-    get_meetings_from(yesterday, 'past')
-
-    destination.close()
+    try:
+        with open_destination(args.destination) as fh:
+            meetings = get_meetings_from(args.date, args.meeting_type, args.key, args.secret)
+            json.dump(meetings, fh, indent=2)
+    except OSError as e:
+        print("Destination error: %s" % str(e))
+    except requests.HTTPError as e:
+        print("Error making API request: %s" % str(e))
+    except ZoomApiException as e:
+        print("The API returned an error response: %s", str(e))
+    except KeyboardInterrupt:
+        print("Quitting")
 
 if __name__ == '__main__':
-    main()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--key", help="zoom api key", default=KEY)
+    parser.add_argument("--secret", help="zoom api secret", default=SECRET)
+    parser.add_argument("--date", help="fetch meetings from this date")
+    parser.add_argument("--destination", help="destination filename", default="-")
+    parser.add_argument("--meeting-type", help="get live or past meetings", default="past")
+    args = parser.parse_args()
+
+    if args.date is None:
+        args.date = (datetime.today() - timedelta(days=1)).strftime('%Y-%m-%d')
+
+    main(args)
 
 


### PR DESCRIPTION
I went a little overboard. Some of these changes are meant to be illustrative of various python idioms and techniques.

* get the `.env` vars up top, use as arg defaults
* moved arg parsing into the `__main__` block
* allow output to stdout
* added a `--date` arg
* refactored so that each run gets either "live" or "past" meetings (not both)
* added some exception handling